### PR TITLE
Add py script to replace .md with .html

### DIFF
--- a/replace_links.py
+++ b/replace_links.py
@@ -1,0 +1,30 @@
+from glob import glob
+import re
+
+def open_file(path):
+    with open(path, mode='r' , encoding='utf_8') as f:
+        data = f.read()
+        return data
+
+def save_file(path, data):
+    with open(path, mode='w', encoding='utf_8') as f:
+        f.write(data)
+
+PTN = "<p align='center'>\n.*\n</p>"
+def remove_links(html):
+    return re.sub(PTN, '', html)
+
+def replace_links(html):
+    return html.replace('.md', '.html')
+
+def main():
+    pth = glob('docs/*.html')
+    typ_pth = glob('docs/type/*.html')
+    paths = pth + typ_pth
+    for path in paths:
+        html = open_file(path)
+        html = remove_links(html)
+        save_file(path, html)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
related: https://github.com/erg-lang/erg/issues/16

I created python3 script that can fix the broken Erg book navigation links at the bottom(Prev|Next) .

Currently, only directories under docs and type are retrieved.

Note that if you add other directories, this will not work properly.